### PR TITLE
introducing interpolation, remove parallelization

### DIFF
--- a/python/lvmdatasimulator/utils.py
+++ b/python/lvmdatasimulator/utils.py
@@ -173,7 +173,6 @@ def chunksize(cube, nchunks=4, overlap=40):
     overlap = int(overlap)
 
     if nchunks == np.sqrt(nchunks) ** 2:
-        print(np.sqrt(nchunks))
         max_chunks = int(np.sqrt(nchunks))
         min_chunks = int(np.sqrt(nchunks))
     else:


### PR DESCRIPTION
I introduced the possibility to use interpolation instead of precise resampling when resampling spectra. It works much faster, but with interpolation the parallelization is damaging, so I modified the parameters in order not to use parallelization